### PR TITLE
setenv.sh includes environment var overrides from the data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN set -x \
     && chown -R daemon:daemon  "${JIRA_INSTALL}/temp" \
     && chown -R daemon:daemon  "${JIRA_INSTALL}/work" \
     && sed --in-place          "s/java version/openjdk version/g" "${JIRA_INSTALL}/bin/check-java.sh" \
-    && sed --in-place          's/JVM_MAXIMUM_MEMORY="768m"/JVM_MAXIMUM_MEMORY="1024m"/' "${JIRA_INSTALL}/bin/setenv.sh" \
+    && sed --in-place          "/In general don't make changes below here/ a\[ -f \"\${JIRA_HOME}/setenv_override.sh\" ] && . \"\${JIRA_HOME}/setenv_override.sh\"" "${JIRA_INSTALL}/bin/setenv.sh" \
     && echo -e                 "\njira.home=$JIRA_HOME" >> "${JIRA_INSTALL}/atlassian-jira/WEB-INF/classes/jira-application.properties" \
     && touch -d "@0"           "${JIRA_INSTALL}/conf/server.xml"
 


### PR DESCRIPTION
Insert a shim into `setenv.sh` to include env vars from a `.sh` file in the data directory. This means we no longer have to bake env var tweaks into the container itself.